### PR TITLE
Fix/auth expirando indevidamente

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -144,6 +144,8 @@ const EventBroadcast = a.model({
   cron: a.string(), // quando kind = CRON
 
   status: BroadcastStatus,
+
+  messages: a.hasMany('OutboundMessage', 'broadcastId')
 }).authorization(allow => [
   allow.group('ADMINS').to(['create', 'read', 'update', 'delete'])
 ])

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -63,6 +63,8 @@ const Event = a.model({
   faqs: a.hasMany('EventFaq', 'eventId'),
   sponsors: a.hasMany('EventSponsor', 'eventId'),
   gallery: a.hasMany('EventImage', 'eventId'),
+
+  broadcasts: a.hasMany('EventBroadcast', 'eventId'),
 }).authorization((allow) => [
   allow.group('ADMINS').to(['create', 'update', 'delete', 'read']),
   allow.authenticated().to(['read']),

--- a/src/components/admin/UpdateCreateEventModal.vue
+++ b/src/components/admin/UpdateCreateEventModal.vue
@@ -413,7 +413,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref, watch, onBeforeUnmount, onMounted } from 'vue'
-import { useEvents, type TalkRow, type SponsorRow } from '@/composables/useEvents'
+import { useEvents, type TalkRow } from '@/composables/useEvents'
 import { useSpeakers } from '@/composables/useSpeakers'
 import { getDataClient } from '@/composables/useData'
 import { uploadData } from 'aws-amplify/storage'
@@ -434,9 +434,9 @@ import outputs from '../../../amplify_outputs.json'
 type EventsHook = ReturnType<typeof useEvents>
 type SpeakersHook = ReturnType<typeof useSpeakers>
 
-const events: EventsHook = useEvents()
-const speakersHook: SpeakersHook = useSpeakers()
-const client = getDataClient()
+const events: EventsHook = useEvents({ mode: 'private' })
+const speakersHook: SpeakersHook = useSpeakers({ mode: 'private' })
+const client = getDataClient('private')
 
 type EventRow = typeof events.items.value[number]
 type SpeakerRow = typeof speakersHook.items.value[number]

--- a/src/components/admin/UpdateCreateSpeakerModal.vue
+++ b/src/components/admin/UpdateCreateSpeakerModal.vue
@@ -149,7 +149,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
 
 type SpeakersHook = ReturnType<typeof useSpeakers>
-const speakers: SpeakersHook = useSpeakers()
+const speakers: SpeakersHook = useSpeakers({ mode: 'private' })
 
 type SpeakerRow = typeof speakers.items.value[number]
 type CreateInput = Parameters<SpeakersHook['createSpeaker']>[0]

--- a/src/composables/useData.ts
+++ b/src/composables/useData.ts
@@ -5,12 +5,13 @@ import { getCurrentUser } from 'aws-amplify/auth'
 import { Hub } from 'aws-amplify/utils'
 
 type Client = ReturnType<typeof generateClient<Schema>>
+type AuthMode = 'public' | 'private'
 
 let publicClient: Client | null = null
 let privateClient: Client | null = null
 
 // estado interno do modo atual
-let authMode: 'public' | 'private' = 'public'
+let authMode: AuthMode = 'public'
 
 // cria (lazy) os dois clientes; chamamos quando necessário
 function ensureClients() {
@@ -43,9 +44,10 @@ void probeAuthMode()
  * Ele alterna entre apiKey (público) e userPool (privado) com base
  * no último estado detectado de autenticação.
  */
-export function getDataClient() {
+export function getDataClient(preferredMode?: AuthMode) {
     ensureClients()
-    return authMode === 'private' ? (privateClient as Client) : (publicClient as Client)
+    const mode: AuthMode = preferredMode ?? authMode
+    return mode === 'private' ? (privateClient as Client) : (publicClient as Client)
 }
 
 /**

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -230,8 +230,8 @@ import { Skeleton } from '@/components/ui/skeleton'
 import SkeletonRows from '@/components/admin/SkeletonRows.vue'
 import { EVENTS_PREFIX } from '@/constants/storage'
 
-const events = reactive(useEvents())
-const speakers = reactive(useSpeakers())
+const events = reactive(useEvents({ mode: 'private' }))
+const speakers = reactive(useSpeakers({ mode: 'private' }))
 
 // Deriva o tipo de linha a partir do estado dos hooks (sem export extra)
 type EventRow = typeof events.items[number]


### PR DESCRIPTION
feat(amplify): adiciona relacionamento de transmissões ao modelo Event
refactor(data): permite especificar o modo de autenticação para getDataClient
refactor(composables): adiciona opção de modo de autenticação para useEvents e useSpeakers
refactor(admin): usa o modo de autenticação 'private' para hooks de dados no painel de administração

O modelo `Event` agora inclui um relacionamento `hasMany` com `EventBroadcast`, permitindo que um evento tenha várias transmissões associadas.

A função `getDataClient` foi aprimorada para aceitar um `preferredMode` opcional, permitindo que os chamadores especifiquem explicitamente se desejam um cliente público ou privado, em vez de depender apenas da detecção automática.

Os composables `useEvents` e `useSpeakers` foram atualizados para aceitar um objeto de opções com uma propriedade `mode`. Isso permite que os componentes que usam esses hooks especifiquem o modo de autenticação desejado ('auto', 'public' ou 'private'), garantindo que o cliente de dados correto seja usado para operações específicas.

No painel de administração, os hooks `useEvents` e `useSpeakers` agora são inicializados com `mode: 'private'`, garantindo que todas as operações de 